### PR TITLE
Update FUZZBUNCH_linux.txt

### DIFF
--- a/Lost_In_Translation/FUZZBUNCH_linux.txt
+++ b/Lost_In_Translation/FUZZBUNCH_linux.txt
@@ -15,7 +15,7 @@ snowden@nsa[~]$ wine regedit.exe
 
 HKCU > Environment > New Key 
 Name: PATH
-Value c:\\windows;c:\\windows\\system;C:\\Python26;C:\\nsa\windows\\fuzzbunch
+Value c:\\windows;c:\\windows\\system;C:\\Python26;C:\\nsa\\fuzzbunch
 
 NB: This will take a while, as .wine will get set up
 


### PR DESCRIPTION
The value of "C:\\nsa\windows\\fuzzbunch" in PATH should be "C:\\nsa\\fuzzbunch" since only windows folder is copied below (step 4)